### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Itip/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Itip/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Itip Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Itip/Integration/ItipTest.php
+++ b/test/Horde/Itip/Integration/ItipTest.php
@@ -26,6 +26,7 @@
  * @author     Gunnar Wrobel <wrobel@pardus.de>
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
+#[\AllowDynamicProperties]
 class Horde_Itip_Integration_ItipTest
 extends Horde_Test_Case
 {

--- a/test/Horde/Itip/Integration/ItipTest.php
+++ b/test/Horde/Itip/Integration/ItipTest.php
@@ -27,19 +27,19 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Itip_Integration_ItipTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         setlocale(LC_ALL, 'C');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         setlocale(LC_ALL, '');
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_transport = new Horde_Mail_Transport_Mock();
     }
@@ -156,7 +156,7 @@ extends PHPUnit_Framework_TestCase
             $this->_transport
         );
         
-        $this->assertContains(
+        $this->assertStringContainsString(
             'From: Mister Test <test@example.org>',
             $this->_transport->sentMessages[0]['header_text']
         );
@@ -181,7 +181,7 @@ extends PHPUnit_Framework_TestCase
             $this->_transport
         );
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'From: "Mr. Test" <test@example.org>',
             $this->_transport->sentMessages[0]['header_text']
         );
@@ -206,7 +206,7 @@ extends PHPUnit_Framework_TestCase
             $this->_transport
         );
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'From: default@example.org',
             $this->_transport->sentMessages[0]['header_text']
         );
@@ -222,7 +222,7 @@ extends PHPUnit_Framework_TestCase
             $this->_transport
         );
         
-        $this->assertContains(
+        $this->assertStringContainsString(
             'To: orga@example.org', 
             $this->_transport->sentMessages[0]['header_text']
         );
@@ -237,7 +237,7 @@ extends PHPUnit_Framework_TestCase
             new Horde_Itip_Response_Options_Kolab(),
             $this->_transport
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Subject: Accepted: Test',
             $this->_transport->sentMessages[0]['header_text']
         );
@@ -252,7 +252,7 @@ extends PHPUnit_Framework_TestCase
             new Horde_Itip_Response_Options_Kolab(),
             $this->_transport
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Subject: Declined: Test',
             $this->_transport->sentMessages[0]['header_text']
         );
@@ -267,7 +267,7 @@ extends PHPUnit_Framework_TestCase
             new Horde_Itip_Response_Options_Kolab(),
             $this->_transport
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Subject: Tentative: Test',
             $this->_transport->sentMessages[0]['header_text']
         );
@@ -282,7 +282,7 @@ extends PHPUnit_Framework_TestCase
             new Horde_Itip_Response_Options_Kolab(),
             $this->_transport
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Subject: Accepted [info]: Test',
             $this->_transport->sentMessages[0]['header_text']
         );
@@ -339,7 +339,7 @@ extends PHPUnit_Framework_TestCase
             new Horde_Itip_Response_Options_Kolab(),
             $this->_transport
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Subject: Declined: Test',
             $this->_transport->sentMessages[0]['header_text']
         );
@@ -354,7 +354,7 @@ extends PHPUnit_Framework_TestCase
             new Horde_Itip_Response_Options_Kolab(),
             $this->_transport
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Subject: Tentative: Test',
             $this->_transport->sentMessages[0]['header_text']
         );
@@ -370,7 +370,7 @@ extends PHPUnit_Framework_TestCase
             new Horde_Itip_Response_Options_Horde('UTF-8', array()),
             $this->_transport
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Message-ID:',
             $this->_transport->sentMessages[0]['header_text']
         );

--- a/test/Horde/Itip/Unit/Event/VeventTest.php
+++ b/test/Horde/Itip/Unit/Event/VeventTest.php
@@ -15,7 +15,7 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Itip_Unit_Event_VeventTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     public function testGetMethodReturnsMethod()
     {

--- a/test/Horde/Itip/Unit/Response/Type/BaseTest.php
+++ b/test/Horde/Itip/Unit/Response/Type/BaseTest.php
@@ -27,13 +27,12 @@
  * @license    http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class Horde_Itip_Unit_Response_Type_BaseTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
-    /**
-     * @expectedException Horde_Itip_Exception
-     */
     public function testExceptionOnUndefinedRequest()
     {
+        $this->expectException('Horde_Itip_Exception');
+
         $type = new Horde_Itip_Response_Type_Accept(
             new Horde_Itip_Resource_Base('', '')
         );


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-itip/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-itip/-/blob/debian-sid/debian/patches/1012_php8.2.patch
