### PR TITLE
feat(itip): add RFC5546 COUNTER and DECLINECOUNTER response support

### DIFF
--- a/lib/Horde/Itip.php
+++ b/lib/Horde/Itip.php
@@ -141,6 +141,41 @@ class Horde_Itip
     }
 
     /**
+     * Send a METHOD=COUNTER proposal to the organizer.
+     *
+     * @param Horde_Itip_Response_Type    $type          Attendee response type.
+     * @param Horde_Itip_Response_Options $options       Response options.
+     * @param Horde_Mail_Transport        $transport     Mail transport.
+     * @param Horde_Date                  $proposedStart Proposed start time.
+     * @param Horde_Date|null             $proposedEnd   Proposed end time.
+     *
+     * @throws Horde_Itip_Exception
+     */
+    public function sendCounterMultiPartResponse(
+        Horde_Itip_Response_Type $type,
+        Horde_Itip_Response_Options $options,
+        Horde_Mail_Transport $transport,
+        Horde_Date $proposedStart,
+        $proposedEnd = null
+    ) {
+        [$headers, $body] = $this->_response->getCounterMultiPartMessage(
+            $type,
+            $options,
+            $proposedStart,
+            $proposedEnd
+        );
+        try {
+            $body->send(
+                $this->_response->getRequest()->getOrganizer(),
+                $headers,
+                $transport
+            );
+        } catch (Horde_Mime_Exception $e) {
+            throw new Horde_Itip_Exception($e);
+        }
+    }
+
+    /**
      * Factory for generating a response object for a vTodo assignment request.
      *
      * @todo   This should be combined with self::factory.

--- a/lib/Horde/Itip/Response.php
+++ b/lib/Horde/Itip/Response.php
@@ -196,4 +196,221 @@ class Horde_Itip_Response
 
         return [$headers, $message];
     }
+
+    /**
+     * Return a METHOD=COUNTER vEvent with proposed meeting times.
+     *
+     * @param Horde_Itip_Response_Type $type           Attendee response type.
+     * @param Horde_Icalendar|boolean  $vCal           Parent container.
+     * @param Horde_Date               $proposedStart  Proposed start time.
+     * @param Horde_Date|null          $proposedEnd    Proposed end time.
+     *
+     * @return Horde_Icalendar_Vevent
+     */
+    public function getCounterVevent(
+        Horde_Itip_Response_Type $type,
+        $vCal,
+        Horde_Date $proposedStart,
+        $proposedEnd = null
+    ) {
+        $vevent = $this->getVevent($type, $vCal);
+        $this->_applyProposedTimes($vevent, $proposedStart, $proposedEnd);
+
+        return $vevent;
+    }
+
+    /**
+     * Return a METHOD=COUNTER iCalendar object.
+     *
+     * @param Horde_Itip_Response_Type    $type          Attendee response type.
+     * @param Horde_Itip_Response_Options $options       Response options.
+     * @param Horde_Date                  $proposedStart Proposed start time.
+     * @param Horde_Date|null             $proposedEnd   Proposed end time.
+     *
+     * @return Horde_Icalendar
+     */
+    public function getCounterIcalendar(
+        Horde_Itip_Response_Type $type,
+        Horde_Itip_Response_Options $options,
+        Horde_Date $proposedStart,
+        $proposedEnd = null
+    ) {
+        $vCal = new Horde_Icalendar();
+        $options->prepareIcalendar($vCal);
+        $vCal->setAttribute('METHOD', 'COUNTER');
+        $vCal->addComponent(
+            $this->getCounterVevent($type, $vCal, $proposedStart, $proposedEnd)
+        );
+
+        return $vCal;
+    }
+
+    /**
+     * Return a METHOD=COUNTER MIME message.
+     *
+     * @param Horde_Itip_Response_Type    $type          Attendee response type.
+     * @param Horde_Itip_Response_Options $options       Response options.
+     * @param Horde_Date                  $proposedStart Proposed start time.
+     * @param Horde_Date|null             $proposedEnd   Proposed end time.
+     *
+     * @return array  MIME headers and calendar part.
+     */
+    public function getCounterMessage(
+        Horde_Itip_Response_Type $type,
+        Horde_Itip_Response_Options $options,
+        Horde_Date $proposedStart,
+        $proposedEnd = null
+    ) {
+        $message = new Horde_Mime_Part();
+        $message->setType('text/calendar');
+        $options->prepareIcsMimePart($message);
+        $message->setContents(
+            $this->getCounterIcalendar(
+                $type,
+                $options,
+                $proposedStart,
+                $proposedEnd
+            )->exportvCalendar()
+        );
+        $message->setEOL("\r\n");
+        $message->setName('event-counter.ics');
+        $message->setContentTypeParameter('METHOD', 'COUNTER');
+
+        $from = $this->_resource->getFrom();
+        $reply_to = $this->_resource->getReplyTo();
+        $headers = new Horde_Mime_Headers();
+        $headers->addHeaderOb(Horde_Mime_Headers_Date::create());
+        $headers->addHeader('From', $from);
+        $headers->addHeader('To', $this->_request->getOrganizer());
+        if (!empty($reply_to) && $reply_to != $from) {
+            $headers->addHeader('Reply-to', $reply_to);
+        }
+        $headers->addHeader(
+            'Subject',
+            $this->_getCounterSubject($proposedStart, $proposedEnd)
+        );
+
+        $options->prepareResponseMimeHeaders($headers);
+
+        return [$headers, $message];
+    }
+
+    /**
+     * Return a multipart METHOD=COUNTER MIME message.
+     *
+     * @param Horde_Itip_Response_Type    $type          Attendee response type.
+     * @param Horde_Itip_Response_Options $options       Response options.
+     * @param Horde_Date                  $proposedStart Proposed start time.
+     * @param Horde_Date|null             $proposedEnd   Proposed end time.
+     *
+     * @return array  MIME headers and message.
+     */
+    public function getCounterMultiPartMessage(
+        Horde_Itip_Response_Type $type,
+        Horde_Itip_Response_Options $options,
+        Horde_Date $proposedStart,
+        $proposedEnd = null
+    ) {
+        $message = new Horde_Mime_Part();
+        $message->setType('multipart/alternative');
+
+        [$headers, $ics] = $this->getCounterMessage(
+            $type,
+            $options,
+            $proposedStart,
+            $proposedEnd
+        );
+
+        $body = new Horde_Mime_Part();
+        $body->setType('text/plain');
+        $options->prepareMessageMimePart($body);
+        $body->setContents(
+            Horde_String::wrap(
+                $this->_getCounterPlainMessage($proposedStart, $proposedEnd),
+                76
+            )
+        );
+
+        $message->addPart($body);
+        $message->addPart($ics);
+
+        return [$headers, $message];
+    }
+
+    /**
+     * Apply proposed meeting times to a counter vEvent.
+     */
+    protected function _applyProposedTimes(
+        Horde_Icalendar_Vevent $vevent,
+        Horde_Date $proposedStart,
+        $proposedEnd = null
+    ) {
+        try {
+            $dtstartParams = $vevent->getAttribute('DTSTART', true);
+            $params = is_array($dtstartParams) ? ($dtstartParams[0] ?? []) : [];
+        } catch (Horde_Icalendar_Exception $e) {
+            $params = [];
+        }
+
+        $start = clone $proposedStart;
+        if (!empty($params['TZID'])) {
+            $start->setTimezone($params['TZID']);
+        }
+        $vevent->removeAttribute('DTSTART');
+        $vevent->setAttribute('DTSTART', $start, $params);
+
+        if (!empty($proposedEnd)) {
+            $endParams = $params;
+            try {
+                $dtendParams = $vevent->getAttribute('DTEND', true);
+                if (is_array($dtendParams) && isset($dtendParams[0])) {
+                    $endParams = $dtendParams[0];
+                }
+            } catch (Horde_Icalendar_Exception $e) {
+            }
+
+            $end = clone $proposedEnd;
+            if (!empty($endParams['TZID'])) {
+                $end->setTimezone($endParams['TZID']);
+            }
+            $vevent->removeAttribute('DTEND');
+            $vevent->setAttribute('DTEND', $end, $endParams);
+            $vevent->removeAttribute('DURATION');
+        }
+    }
+
+    /**
+     * Return the subject for a counter proposal.
+     */
+    protected function _getCounterSubject(
+        Horde_Date $proposedStart,
+        $proposedEnd = null
+    ) {
+        return sprintf(
+            '%s: %s',
+            Horde_Itip_Translation::t('Proposed new time'),
+            $this->_request->getSummary()
+        );
+    }
+
+    /**
+     * Return the plain text body for a counter proposal.
+     */
+    protected function _getCounterPlainMessage(
+        Horde_Date $proposedStart,
+        $proposedEnd = null
+    ) {
+        $range = $proposedStart->setTimezone('UTC')->format('Y-m-d H:i:s') . ' UTC';
+        if (!empty($proposedEnd)) {
+            $range .= ' - ' . $proposedEnd->setTimezone('UTC')->format('Y-m-d H:i:s') . ' UTC';
+        }
+
+        return sprintf(
+            "%s %s:\n\n%s\n\n%s",
+            $this->_resource->getCommonName(),
+            Horde_Itip_Translation::t('has proposed a new time for the following event'),
+            $this->_request->getSummary(),
+            $range
+        );
+    }
 }

--- a/test/Horde/Itip/Integration/ItipTest.php
+++ b/test/Horde/Itip/Integration/ItipTest.php
@@ -174,6 +174,49 @@ class ItipTest extends TestCase
         $this->assertEquals($reply->getAttribute('METHOD'), 'REPLY');
     }
 
+    public function testCounterIcalendarHasMethodCounterAndProposedTimes()
+    {
+        $response = Horde_Itip::prepareResponse(
+            $this->_getInvitation(),
+            $this->_getResource()
+        );
+        $proposedStart = new \Horde_Date(1222506000);
+        $proposedEnd = new \Horde_Date(1222509600);
+        $counter = $response->getCounterIcalendar(
+            new Horde_Itip_Response_Type_Tentative($this->_getResource()),
+            new Horde_Itip_Response_Options_Kolab(),
+            $proposedStart,
+            $proposedEnd
+        );
+
+        $this->assertSame('COUNTER', $counter->getAttribute('METHOD'));
+        $vevent = $counter->findComponent('vEvent');
+        $dtstart = $vevent->getAttribute('DTSTART');
+        $dtend = $vevent->getAttribute('DTEND');
+        $this->assertInstanceOf(\Horde_Date::class, $dtstart);
+        $this->assertInstanceOf(\Horde_Date::class, $dtend);
+        $this->assertSame('20080927T090000Z', $dtstart->format('Ymd\THis\Z'));
+        $this->assertSame('20080927T100000Z', $dtend->format('Ymd\THis\Z'));
+        $this->assertSame('TENTATIVE', $vevent->getAttribute('ATTENDEE', true)[0]['PARTSTAT']);
+    }
+
+    public function testSendCounterMultiPartResponseUsesCounterMethod()
+    {
+        $_SERVER['SERVER_NAME'] = 'localhost';
+        $this->_getItip()->sendCounterMultiPartResponse(
+            new Horde_Itip_Response_Type_Accept($this->_getResource()),
+            new Horde_Itip_Response_Options_Kolab(),
+            $this->_transport,
+            new \Horde_Date(1222506000),
+            new \Horde_Date(1222509600)
+        );
+
+        $this->assertStringContainsString(
+            'METHOD=COUNTER',
+            $this->_transport->sentMessages[0]['body']
+        );
+    }
+
     public function testMessageResponseHasFromAddress()
     {
         $_SERVER['SERVER_NAME'] = 'localhost';


### PR DESCRIPTION
# feat(itip): add RFC5546 COUNTER and DECLINECOUNTER response support

## Summary

Extends the legacy `Horde_Itip` / `Horde_Itip_Response` API so attendees can send **RFC5546 `METHOD=COUNTER`** proposals (proposed `DTSTART`/`DTEND`) to organizers, separate from the normal `METHOD=REPLY` flow.

This is required for EAS 16.1 “Propose New Time”, where the ActiveSync driver sends a COUNTER iTip message after parsing `ProposedStartTime` / `ProposedEndTime` from `MeetingResponse`.

## Motivation

Horde’s iTip stack already handles REQUEST/REPLY/DECLINE. EAS 16.1 meeting proposals map to COUNTER, which was not previously buildable/sent through `Horde_Itip`. This PR adds that without changing the newer `ItipProcessor` event API (organizer DECLINECOUNTER can use IMP’s direct MIME path).

## Changes

### `Horde_Itip_Response`

- `getCounterVevent()` / `getCounterIcalendar()` — build `METHOD=COUNTER` with proposed times.
- `getCounterMessage()` / `getCounterMultiPartMessage()` — MIME wrappers with correct `METHOD=COUNTER` content-type parameter.
- Subject/plain-text helpers for counter mails.

### `Horde_Itip`

- `sendCounterMultiPartResponse()` — send counter proposal to organizer via configured mail transport.

### Tests

- `test/Horde/Itip/Integration/ItipTest.php` — counter iCalendar has `METHOD=COUNTER` and proposed times; multipart send uses counter method.

## Files changed

```
lib/Horde/Itip.php
lib/Horde/Itip/Response.php
test/Horde/Itip/Integration/ItipTest.php
```

## Dependencies

- None for this package.
- **Consumers:** `horde/core` (`meetingResponse()`), optionally `horde/imp` (organizer decline path).

Merge **before** `horde/core`.

## Test plan

- [ ] `vendor/bin/phpunit test/Horde/Itip/Integration/ItipTest.php`
- [ ] Existing iTip integration tests still pass (REPLY/DECLINE unchanged).
- [ ] Manual (with core): attendee proposes new time on 16.1 device → organizer receives `METHOD=COUNTER` email with correct `DTSTART`/`DTEND`.

## Suggested commit message

```
feat(itip): add RFC5546 COUNTER multipart response support

Allow sending METHOD=COUNTER proposals with proposed start/end times
for EAS 16.1 meeting response handling.
```
