### PR TITLE
feat(itip): add MimeEnvelopeBuilder for invitation mail

### DIFF
--- a/src/Generator/MimeEnvelopeBuilder.php
+++ b/src/Generator/MimeEnvelopeBuilder.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author    Torben Dannhauer <torben@dannhauer.de>
+ * @category  Horde
+ * @copyright 2026 The Horde Project
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Itip
+ */
+
+namespace Horde\Itip\Generator;
+
+use Horde_Mime_Part;
+
+/**
+ * Builds a canonical multipart/alternative iTIP invitation envelope.
+ */
+final class MimeEnvelopeBuilder
+{
+    /**
+     * @param string $plainBody  text/plain body.
+     * @param string $htmlBody   text/html body.
+     * @param string $icsData    iCalendar payload.
+     * @param string $method     iTIP METHOD value (REQUEST, CANCEL, …).
+     */
+    public function build(
+        string $plainBody,
+        string $htmlBody,
+        string $icsData,
+        string $method,
+    ): Horde_Mime_Part {
+        $multipart = new Horde_Mime_Part();
+        $multipart->setType('multipart/alternative');
+
+        $bodyText = new Horde_Mime_Part();
+        $bodyText->setType('text/plain');
+        $bodyText->setCharset('UTF-8');
+        $bodyText->setContents($plainBody);
+        $bodyText->setDisposition('inline');
+        $multipart->addPart($bodyText);
+
+        $bodyHtml = new Horde_Mime_Part();
+        $bodyHtml->setType('text/html');
+        $bodyHtml->setCharset('UTF-8');
+        $bodyHtml->setContents($htmlBody);
+        $bodyHtml->setDisposition('inline');
+        $multipart->addPart($bodyHtml);
+
+        $icsInline = new Horde_Mime_Part();
+        $icsInline->setType('text/calendar');
+        $icsInline->setContents($icsData);
+        $icsInline->setContentTypeParameter('method', $method);
+        $icsInline->setCharset('UTF-8');
+        $icsInline->setDisposition('inline');
+        $icsInline->setEOL("\r\n");
+        $multipart->addPart($icsInline);
+
+        return $multipart;
+    }
+}

--- a/test/Unit/MimeEnvelopeBuilderTest.php
+++ b/test/Unit/MimeEnvelopeBuilderTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author    Torben Dannhauer <torben@dannhauer.de>
+ * @category  Horde
+ * @copyright 2026 The Horde Project
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Itip
+ */
+
+namespace Horde\Itip\Test\Unit;
+
+use Horde\Itip\Generator\MimeEnvelopeBuilder;
+use Horde_Mime_Part;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MimeEnvelopeBuilder::class)]
+class MimeEnvelopeBuilderTest extends TestCase
+{
+    public function testBuildCreatesMultipartAlternativeWithCalendarPart(): void
+    {
+        $builder = new MimeEnvelopeBuilder();
+        $message = $builder->build(
+            'Plain invitation',
+            '<p>HTML invitation</p>',
+            "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nEND:VCALENDAR\r\n",
+            'REQUEST'
+        );
+
+        $this->assertSame('multipart/alternative', $message->getType());
+
+        $types = [];
+        foreach ($message->getParts() as $part) {
+            $types[] = $part->getType();
+        }
+
+        $this->assertSame(['text/plain', 'text/html', 'text/calendar'], $types);
+
+        $calendar = $message->getPart(3);
+        $this->assertInstanceOf(Horde_Mime_Part::class, $calendar);
+        $this->assertSame('REQUEST', $calendar->getContentTypeParameter('method'));
+        $this->assertSame('inline', $calendar->getDisposition());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Horde\Itip\Generator\MimeEnvelopeBuilder` for outbound invitation MIME
- PHPUnit test asserts part types and inline calendar method parameter

## Motivation
Kronolith and other callers need one canonical `multipart/alternative`
structure (plain, HTML, inline `text/calendar`) instead of ad-hoc MIME
assembly with duplicate attachments.

## Changes
- New `src/Generator/MimeEnvelopeBuilder.php`
- New `test/Unit/MimeEnvelopeBuilderTest.php`
- New files use `The Horde Project` copyright (Horde LLC no longer exists); contributor credit via `@author Torben Dannhauer <torben@dannhauer.de>`

## Test plan
- [x] `vendor/bin/phpunit --bootstrap vendor/autoload.php -c phpunit.xml.dist test/Unit/MimeEnvelopeBuilderTest.php`
